### PR TITLE
add(example.rb): Add example ruby agent plugin.

### DIFF
--- a/examples/example.rb
+++ b/examples/example.rb
@@ -1,4 +1,21 @@
 #!/usr/bin/env ruby
+## Rackspace Cloud Monitoring Plug-In
+## Example ruby plug-in
+#
+# (C)2013 Jay Faulkner <jay.faulkner@rackspace.com>
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # example.rb
 #  - A ruby example of a Rackspace Cloud Montioring Agent plugin


### PR DESCRIPTION
I'm not sure if this is needed or helpful? I'm probably going to use this for all my new agent plugins and thought it could be valuable for others' use.

Thoughts?
