### PR TITLE
Update cman_tool check for rackspace monitoring

### DIFF
--- a/cman_nodes.rb
+++ b/cman_nodes.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-
+## Rackspace Cloud Monitoring Plug-In
+## CMAN nodes check
+#
 # Author: James Turnbull
 # Copyright (c) 2012 James Turnbull <james@lovedthanlost.net>
 #
@@ -21,20 +23,72 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+#
+# Usage:
+# Place plug-in in /usr/lib/rackspace-monitoring-agent/plugins
+#
+# The following is an example 'criteria' for a Rackspace Monitoring Alarm:
+#
+# if (metric['NODE_STATUS'] == 'X') {
+#   return new AlarmStatus(CRITICAL, 'Host is not a member of the cluster!');
+# }
+#
+# if (metric['NODE_STATUS'] < 'd') {
+#   return new AlarmStatus(CRITICAL, 'Host is disallowed from cluster!');
+# }
+#
+# return new AlarmStatus(OK, 'Host is a member of the cluster.');
+#
 
+# If the plugin fails in any way, print why and exit nonzero.
+def fail(status="Unknown failure")
+  puts "status #{status}"
+  exit 1
+end
 
-hostname = `hostname -s`.chomp
+# Store metrics in a hash and don't print them until we've completed
+def metric(name,type,value)
+  @metrics[name] = {
+    :type => type,
+    :value => value
+  }
+end
+
+# Once the script has succeeded without errors, print metrics lines.
+def output_success
+  puts "status Cman node status for #{@hostname}"
+  @metrics.each do |name,v|
+    puts "metric #{name} #{v[:type]} #{v[:value]}"
+  end
+end
 
 begin
-  status = `cman_tool nodes -n #{hostname} -F type`
-  case status
-  when 'X'
-    puts "status err Cluster node #{hostname} is not a member of the cluster."
-  when 'd'
-    puts "status err Cluster node #{hostname} is disallowed from the cluster."
-  else
-   puts "status ok Cluster node #{hostname} is a member of the cluster." 
-  end
-rescue => e
-  puts "status err Problem running cman_tool plugin: #{e.message}"
+  require 'optparse'
+rescue
+  fail "Failed to load required ruby gems!"
 end
+
+@metrics = {}
+options = {}
+
+args = ARGV.dup
+
+OptionParser.new do |o|
+  o.banner = "Usage: #{$0} [options]"
+  o.on('-h', '--hostname HOSTNAME', 'Check status of node lid option') do |h| 
+    options[:host] = h 
+  end
+  o.on_tail('-h', '--help', 'Show this message') { puts o; exit }
+  o.parse!(args)
+end
+
+@hostname = options[:host] || `hostname -s`.chomp
+
+begin
+  node_status = `cman_tool nodes -n #{@hostname} -F type`
+  metric("node_status","string","#{node_status}")
+rescue => e
+  fail "Problem running cman_tool plugin: #{e.message}"
+end
+
+output_success


### PR DESCRIPTION
Caveat: This appears correct (re: statuses for alarm examples) based on the old plugin and some googling about cman, but I don't have a CMAN instance to test this on.
