### PR TITLE
Updated watches

### DIFF
--- a/lsyncd-status.sh
+++ b/lsyncd-status.sh
@@ -76,7 +76,7 @@ else
 	echo "status ${SERVICE} not installed"
 fi
 # calculate current directories to watch
-current_directories_to_watch=$(find ${SOURCE} -type d | wc -l | awk '{print $1*2}')
+current_directories_to_watch=$(find ${SOURCE} -type d | wc -l | awk '{print $1}')
 # calculate percenentage of total
 current_percentage=$(echo "${current_directories_to_watch}/${current_inotify_watches}" | bc -l | awk '{printf "%f", $1*100}')
 


### PR DESCRIPTION
Previous value for watches was configured based on a value that was doubled to provide room for growth.  This doesn't accurately represent the value that should be returned.  
