### PR TITLE
Changed method for determining directories to be watched

### DIFF
--- a/lsyncd-status.sh
+++ b/lsyncd-status.sh
@@ -28,8 +28,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# See https://github.com/robszumski/rackspace-monitoring-varnish for a readme
-# and more information
 #
 # Verify the current status of lsyncd
 # *****************


### PR DESCRIPTION
Now correctly determines all directories configured - not just based off the first entry
