### PR TITLE
Divide by 0

### DIFF
--- a/mongodb_stats.py
+++ b/mongodb_stats.py
@@ -60,7 +60,7 @@ def main():
         print "metric index_percent int", float(s['indexCounters']['hits']
                                             / s['indexCounters']['accesses'])
     except ZeroDivisionError:
-        print "metric index_percent int", 0
+        print "metric index_percent int 0"
     if 'repl' in s:
         print "metric is_replicating string true"
         print "metric is_master string", s['repl']['ismaster']


### PR DESCRIPTION
Especially on mongodb servers living in vagrant boxes while writing puppet modules, catch a zero division exception.
