### PR TITLE
backwards-compatible to pymongo 2.1.1

### DIFF
--- a/mongodb_stats.py
+++ b/mongodb_stats.py
@@ -20,14 +20,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import sys
-from pymongo import MongoClient
-from pymongo.errors import ConnectionFailure
+try:
+    from pymongo import MongoClient as Client
+except ImportError:
+    from pymongo import Connection as Client
+from pymongo.errors import ConnectionFailure, AutoReconnect
 
 
 def mongodb_stats(host, port):
     try:
-        c = MongoClient(host, port)
-    except ConnectionFailure:
+        c = Client(host, port)
+    except ConnectionFailure, AutoReconnect:
         return None
     else:
         return c.test.command("serverStatus")


### PR DESCRIPTION
Add backward-compatibility for pymongo-2.1.1, which is offered as an RPM on EL6 compiled with bson support and is easier to install on servers (for example, puppet has a yum provider but not a pip provider without writing your own).

Is there a better way of doing this or is it just going to have to be as ugly as I've made it? o.O
