### PR TITLE
Add holland plugin

### DIFF
--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -21,7 +21,7 @@
 # Also monitors the dump file taken by Holland and the Holland logs.
 #
 # Requirements:
-# Python 2.5 or greater
+# Python 2.4 or greater
 #
 # Usage:
 # Place script in /usr/lib/rackspace-monitoring-agent/plugins
@@ -31,22 +31,18 @@
 # if (metric['sql_ping_succeeds'] == 'false') { 
 #  return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL is not running.'); 
 # } 
-# 
 # if (metric['sql_creds_exist'] == 'false') { 
 #   return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials file \
 #            does not exist.'); 
 # } 
-# 
 # if (metric['sql_status_succeeds'] == 'false') { 
 #   return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials do \
 #            not authenticate.'); 
 # } 
-# 
 # if (metric['dump_age'] > 172800) { 
 #   return new AlarmStatus(CRITICAL, 'holland-plugin: mysqldump file is older \
 #            than 2d.'); 
 # } 
-# 
 # if (metric['error_count'] > 0) { 
 #   return new AlarmStatus(CRITICAL, 'holland-plugin: #{last_error}.'); 
 # } 


### PR DESCRIPTION
This is the plugin that is being configured on all new managed cloud LAMP builds (with some minor formatting changes, and additional docs within the file).

It monitors MySQL to ensure that holland can connect to it using the credentials from Holland's own config file.  Also monitors the holland log file for errors, and the dump file created to ensure it is recent.
