### PR TITLE
Update lsyncd-status.sh

### DIFF
--- a/lsyncd-status.sh
+++ b/lsyncd-status.sh
@@ -54,7 +54,7 @@
 
 SERVICE="lsyncd"
 RESULT=$(pgrep ${SERVICE})
-if [[ "${RESULT:-null}" = null ]]; then
+if [[ -n "${RESULT}" ]]; then
 	echo "metric ${SERVICE}_status string notrunning"
 else
 	echo "metric ${SERVICE}_status string running"


### PR DESCRIPTION
I found that "${RESULT:-null}" = null always evaluated to FALSE and therefor the script would say the service IS running.
