### PR TITLE
Update lsyncd-status.sh

### DIFF
--- a/lsyncd-status.sh
+++ b/lsyncd-status.sh
@@ -53,7 +53,7 @@
 
 
 SERVICE="lsyncd"
-RESULT=$(pgrep ${SERVICE})
+RESULT=$(pgrep -x ${SERVICE})
 if [[ "${RESULT:-null}" = null ]]; then
 	echo "metric ${SERVICE}_status string notrunning"
 else


### PR DESCRIPTION
pgrep -x only matches processes whose name is exactly "lsyncd". Otherwise, the script, lsyncd-status.sh, will find itself when it runs.
