### PR TITLE
Parse only lines with ":" from "show slave status"

### DIFF
--- a/mysql_replication.py
+++ b/mysql_replication.py
@@ -72,7 +72,8 @@ if OUTPUT != "":
 
     SLAVE_STATUS = {}
     for i in SHOW_STATUS_LIST:
-        SLAVE_STATUS[i.split(':')[0].strip()] = i.split(':')[1].strip()
+        if ":" in i:
+            SLAVE_STATUS[i.split(':')[0].strip()] = i.split(':')[1].strip()
 
     if SLAVE_STATUS["Slave_IO_Running"] == "Yes" and \
             SLAVE_STATUS["Slave_SQL_Running"] == "Yes" and \


### PR DESCRIPTION
Issue Details: https://github.com/racker/rackspace-monitoring-agent-plugins-contrib/issues/21

This is to fix the error that came up when trying to parse the following section of the "show slave status" command (i.e. lines without a colon):

```
      Replicate_Wild_Do_Table: 
  Replicate_Wild_Ignore_Table: 
                   Last_Errno: 1580
                   Last_Error: Error 'You cannot 'ALTER' a log table if logging is enabled' on query. Default database: 'mysql'. Query: 'ALTER TABLE slow_log
   MODIFY start_time TIMESTAMP NOT NULL,
   MODIFY user_host MEDIUMTEXT NOT NULL,
```
