### PR TITLE
Fix grabbing token

### DIFF
--- a/cloudbackup_mon.sh
+++ b/cloudbackup_mon.sh
@@ -78,7 +78,7 @@ username=`cat /etc/driveclient/bootstrap.json | grep Username | awk '{print $3}'
 agentid=`cat /etc/driveclient/bootstrap.json | grep AgentId | awk '{print $3}' | sed -e 's/,//g'`
 
 # Get token
-token=`curl -s -I -H "X-Auth-Key: $1" -H "X-Auth-User: $username" https://auth.api.rackspacecloud.com/v1.0 | grep X-Auth-Token |awk {'print $2'}`
+token=`curl -s -I -H "X-Auth-Key: $1" -H "X-Auth-User: $username" https://auth.api.rackspacecloud.com/v1.0 | grep -vi 'vary:' | grep -i X-Auth-Token |awk {'print $2'}`
 
 # Get report ID:
 last_report=`curl -s -H "X-Auth-Token: $token" https://backup.api.rackspacecloud.com/v1.0/backup-configuration/system/$agentid | python -m json.tool |grep LastRunBackupReportId | awk '{print $2}' | sed -e 's/,//g'`


### PR DESCRIPTION
I came across this while looking for projects that assume the case of `X-Auth-Token`.  There's actually two issues:
- HTTP header names are case insensitive according to [rfc 1945](https://tools.ietf.org/html/rfc1945#section-4.2)
- It was actually matching this: `vary: Accept, Accept-Encoding, X-Auth-Token, X-Auth-Key, X-Storage-User, X-Storage-Pass, X-Auth-User`

This is also using the Rackspace Identity v1.0 service.  It won't work with with the v1.1 or v2.0 services.  If it's possible, you should probably use one of the [supported SDKs](http://developer.rackspace.com/#home-sdks) or the [official clients](https://wiki.openstack.org/wiki/OpenStackClients).
