### PR TITLE
rework ntp_offset.sh

### DIFF
--- a/ntp_offset.sh
+++ b/ntp_offset.sh
@@ -4,6 +4,7 @@
 # Rackspace Cloud Monitoring Plugin to verify the time offset from ntp
 #
 # Copyright (c) 2013, Jordan Evans <jordan.evans@rackspace.com>
+# Copyright (c) 2014, Simon Vetter <simon.vetter@runbox.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,34 +33,44 @@
 # This plugin expects to find ntpq and awk in the environment
 # it reports the average ntp offset from ntpq in milliseconds.
 #
-# Example criteria :
-# if (metric['ntp_offset'] > 10000) {
+# Example alarm code:
+# :set consecutiveCount=3
+# if (metric['ntp_offset'] > 10000 || metric['ntp_offset'] < -10000) {
 #   return new AlarmStatus(CRITICAL, 'ntp offset is too high.');
 # }
 # return new AlarmStatus(OK, 'ntp offset is fine.');
+#
+# if (metric['active_sources'] < 2) {
+#   return new AlarmStatus(WARNING, 'ntpd is only using #{active_sources} sources');
+# }
+# return new AlarmStatus(OK, 'ntpd has #{active_sources} active sources');
 #
 
 NTPQ_BIN=$(which ntpq)
 AWK_BIN=$(which awk)
 
-average() {
-  count=0
-  sum=0
-  for x in $1
-  do
-    sum=$(($sum + $x))
-    count=$(($count + 1))
-  done
-  echo $(($sum / $count))
-}
-
-if [ -x $NTPQ_BIN ] && [ -x $AWK_BIN ]
+if [[ -x $NTPQ_BIN ]] && [[ -x $AWK_BIN ]]
   then
-    OUTPUT=$($NTPQ_BIN -pn | $AWK_BIN '{ if ($9 ~ /[0-9]/) print $9};' | cut -f 1 -d '.')
-    OUTPUT=${OUTPUT/-/}
-    AVG=$(average $OUTPUT)
-    echo "metric ntp_offset int32 $AVG"
-    echo "status ok ntp_offset calculated and reported."
+    # only select line starting with * (system peer), + (candidate), # (selected), and o (pps sys peer)
+    OUTPUT=$($NTPQ_BIN -pn | $AWK_BIN '{ if ($1 ~ "^[\\*\\+#o].*" && $9 ~ /[0-9]/) print $9};' | cut -f 1 -d '.')
+
+    for x in ${OUTPUT}
+    do
+      sum=$(($sum + $x))
+      count=$(($count + 1))
+    done
+
+    if [[ ${count} -gt 0 ]]; then
+      avg=$(($sum / $count))
+      echo "status ok got ntp stats"
+      echo "metric ntp_offset int32 ${avg} milliseconds"
+      echo "metric active_sources uint32 ${count} sources"
+      exit 0
+    else
+      echo "status could not compute ntp offset: no reachable or active source"
+    fi
   else
-    echo "status err ntpq or awk is not executable"
+    echo "status could not compute ntp offset: ntpq and/or awk could not be found"
 fi
+
+exit 1

--- a/ntp_offset.sh
+++ b/ntp_offset.sh
@@ -67,10 +67,10 @@ if [[ -x $NTPQ_BIN ]] && [[ -x $AWK_BIN ]]
       echo "metric active_sources uint32 ${count} sources"
       exit 0
     else
-      echo "status could not compute ntp offset: no reachable or active source"
+      echo "status err could not compute ntp offset: no reachable or active source"
     fi
   else
-    echo "status could not compute ntp offset: ntpq and/or awk could not be found"
+    echo "status err could not compute ntp offset: ntpq and/or awk could not be found"
 fi
 
 exit 1


### PR DESCRIPTION
This changes the plugin so that it:
- computes correct average values,
- emits the number of current active time sources as a metric,
- exits with 1 if the average offset can't be computed for any reason