### PR TITLE
Holland Plugin Fixes

### DIFF
--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -171,9 +171,15 @@ class MySQL:
                     "/usr/bin/mysqladmin",
                     "-u",self.user,
                     "-p"+self.password,
-                    "status"])
+                    "status"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL)
             else:
-                status = subprocess.call(["/usr/bin/mysqladmin","status"])
+                status = subprocess.call([
+                    "/usr/bin/mysqladmin",
+                    "status"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL)
         except:
             return 'false'
         else:

--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -119,15 +119,15 @@ class MySQL:
         self.config_file = "/etc/holland/providers/mysqldump.conf"
         self.user = get_conf_value(self.config_file, 'user')
         self.password = get_conf_value(self.config_file, 'password')
-        self.creds_file = get_conf_value(self.config_file, 
-            'defaults-extra-file').split(',')
+        self.creds_file = get_conf_value(self.config_file,
+                                         'defaults-extra-file')
 
     # return true if credentials set
     def check_creds(self):
         if (self.user and self.password):
             return 'true'
         elif self.creds_file:
-            for f in self.creds_file:
+            for f in self.creds_file.split(','):
                 if os.access(f, os.F_OK):
                     return 'true'
             return 'false'
@@ -155,7 +155,7 @@ class MySQL:
         try:
             DEVNULL = open(os.devnull, 'wb')
             if self.creds_file:
-                for f in self.creds_file:
+                for f in self.creds_file.split(','):
                     try:
                         status = subprocess.call([
                             "/usr/bin/mysqladmin",


### PR DESCRIPTION
A few fixes based on previous feedback:

 * Ensure output of `mysqladmin status` goes to `/dev/null`
 * Don't do `.split()` on `None` value
 * Look in `/etc/holland/backupsets/default.conf` for credentials before `mysqldump.conf`, as this is where dedicated support teams often configure things and that location takes precedence.

The first two of these have been used in lamp builds for a while now.  The third one is new.