### PR TITLE
Added read the --defaults-file to check_ping()

### DIFF
--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -134,12 +134,36 @@ class MySQL:
         else:
             return 'false'
 
-    # return true if ping succeeds
+        # return true if ping succeeds
     def check_ping(self):
         try:
             DEVNULL = open(os.devnull, 'wb')
-            ping = subprocess.call(["/usr/bin/mysqladmin","ping"], 
-                stdout=DEVNULL, stderr=DEVNULL)
+            if self.creds_files:
+                for f in self.creds_files.split(','):
+                    try:
+                        ping = subprocess.call([
+                            "/usr/bin/mysqladmin",
+                            "--defaults-file="+f,"ping"],
+                            stdout=DEVNULL,
+                            stderr=DEVNULL)
+                        if ping == 0:
+                            break
+                    except:
+                        ping = 0
+            elif self.user and self.password:
+                ping = subprocess.call([
+                    "/usr/bin/mysqladmin",
+                    "-u",self.user,
+                    "-p"+self.password,
+                    "ping"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL)
+            else:
+                ping = subprocess.call([
+                    "/usr/bin/mysqladmin",
+                    "ping"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL)
         except:
             return 'false'
         else:


### PR DESCRIPTION
First time doing a pull request. 

As per the initial email thread:

Yesterday we ran into a server that had the holland_mysqldump.py plugin enabled but it would return that MySQL is not running, meaning it was failing the check_ping() function.

Running the plugin directly from the CLI it would return the correct response "metric sql_ping_succeeds string true” but the monitoring agent would get a “false" whenever it would run the check.

We found that check_status() would work correctly on both cases via CLI and agent. The difference between the check_ping() and check_status() is that check_status() will explicitly try to read the —defaults-file with a try block