### PR TITLE
chef_node_checkin: short out when log is empty

### DIFF
--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -4,6 +4,11 @@ from datetime import datetime, timedelta
 import time
 import os
 
+if os.stat('/var/log/chef/client.log').st_size == 0:
+    print "status Warning node has not generated a client log"
+    print "metric timeSinceCheckIn int32", 0
+    os._exit(0)
+
 logFile = open('/var/log/chef/client.log', 'r')
 
 clientRuns = []

--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -54,15 +54,15 @@ try:
     metrics = PopulateMetrics(logfile)
 
 # Anything OS related with file handling should warn and exit
-except IOError:
+except IOError as err:
     print "status Warning there was an error handling {0}".format(err)
 
 # Handle the log regex not returning a poplated array
 except IndexError:
     print "status OK node has not generated a parsable log"
 
-except as err:
-    print "status Warning {0}".format(err)
+except:
+    print "status Warning unhandled error executing script"
 
 # Always print out metrics to allow REACH to report metrics
 finally:

--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 if os.stat('/var/log/chef/client.log').st_size == 0:
-    print "status Warning node has not generated a client log"
+    print "status OK node has not generated a client log"
     print "metric timeSinceCheckIn int32 0"
     print "metric checkInDuration int32 0"
     print "metric numberOfClients int32 0"

--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -3,11 +3,14 @@ import re
 from datetime import datetime, timedelta
 import time
 import os
+import sys
 
 if os.stat('/var/log/chef/client.log').st_size == 0:
     print "status Warning node has not generated a client log"
-    print "metric timeSinceCheckIn int32", 0
-    os._exit(0)
+    print "metric timeSinceCheckIn int32 0"
+    print "metric checkInDuration int32 0"
+    print "metric numberOfClients int32 0"
+    sys.exit(0)
 
 logFile = open('/var/log/chef/client.log', 'r')
 

--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -3,48 +3,61 @@ import re
 from datetime import datetime, timedelta
 import time
 import os
-import sys
-
-if os.stat('/var/log/chef/client.log').st_size == 0:
-    print "status OK node has not generated a client log"
-    print "metric timeSinceCheckIn int32 0"
-    print "metric checkInDuration int32 0"
-    print "metric numberOfClients int32 0"
-    sys.exit(0)
-
-logFile = open('/var/log/chef/client.log', 'r')
-
-clientRuns = []
-response   = []
-
-for line in logFile:
-    match = re.search('INFO: Chef Run complete in', line)
-    if match:
-        date = re.split('-|T|\+|\:',(line.split()[0])[1:][:-1])
-        clientRuns.append(datetime(int(date[0]),int(date[1]),int(date[2]),int(date[3]),int(date[4]), int(date[5]), 0))
-        checkInDuration = int(float(line.split()[6]))
 
 
-timeSinceCheckIn = int(datetime.now().strftime('%s')) - int(sorted(clientRuns)[-1].strftime('%s'))
+def PopulateMetrics(log):
+    clientRuns = []
+    response = []
+    logFile = open(log, 'r')
+    for line in logFile:
+        match = re.search('INFO: Chef Run complete in', line)
+        if match:
+            date = re.split('-|T|\+|\:', (line.split()[0])[1:][:-1])
+            clientRuns.append(datetime(int(date[0]), int(date[1]), int(
+                date[2]), int(date[3]), int(date[4]), int(date[5]), 0))
+            checkInDuration = int(float(line.split()[6]))
 
+    timeSinceCheckIn = int(
+        datetime.now().strftime('%s')) - int(sorted(clientRuns)[-1].strftime('%s'))
+
+    processesAmount = 0
+    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    for pid in pids:
+        match = re.search(
+            'chef-client', open(os.path.join('/proc', pid, 'cmdline'), 'rb').read())
+        if match:
+            processesAmount += 1
+
+    if timeSinceCheckIn > 86400:
+        print "status Critcal node has not checked in for {0} seconds".format(timeSinceCheckIn)
+    elif timeSinceCheckIn > 3600:
+        print "status Warning node has not checked in for {0} seconds".format(timeSinceCheckIn)
+    else:
+        print "status OK node checked in {0} seconds ago".format(timeSinceCheckIn)
+
+
+logfile = '/var/log/chef/client.log'
+
+checkInDuration = 0
 processesAmount = 0
+timeSinceCheckIn = 0
 
-pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+try:
+    PopulateMetrics(logfile)
 
-for pid in pids:
-  match = re.search('chef-client', open(os.path.join('/proc', pid, 'cmdline'), 'rb').read())
-  if match:
-    processesAmount += 1
+# Anything OS related with file handling should warn and exit
+except IOError as err:
+    print "status Warning there was an error handling {0}".format(logfile)
 
-if timeSinceCheckIn > 86400:
-	print "status Critical node has not checked in for", timeSinceCheckIn, "seconds"
-elif timeSinceCheckIn > 3600:
-    print "status Warning node has not checked in for", timeSinceCheckIn, "seconds"
-else:
-	print "status OK node checked in", timeSinceCheckIn, "seconds ago"
+# Handle the log regex not returning a poplated array meaning an
+except IndexError:
+    print "status OK node has not generated a parsable log"
 
-print "metric timeSinceCheckIn int32", timeSinceCheckIn
+except:
+    print "status Warning unhandled error executing script"
 
-print "metric checkInDuration int32", checkInDuration
-
-print "metric numberOfClients int32", processesAmount
+# Print out even zero values to allow for REACH to show exported metrics
+finally:
+    print "metric timeSinceCheckIn int32", timeSinceCheckIn
+    print "metric checkInDuration int32", checkInDuration
+    print "metric numberOfClients int32", processesAmount

--- a/chef_node_checkin.py
+++ b/chef_node_checkin.py
@@ -55,7 +55,7 @@ try:
 
 # Anything OS related with file handling should warn and exit
 except IOError as err:
-    print "status Warning there was an error handling {0}".format(err)
+    print "status Warning {0}".format(err)
 
 # Handle the log regex not returning a poplated array
 except IndexError:


### PR DESCRIPTION
It can be argued that the intent of the plugin is about clients that haven't converged and shorting out because the log is empty violates this.  However, generating alerts for logs that recently rotated just cries wolf too often to be of use.