### PR TITLE
Holland MySQLdump check 

### DIFF
--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -55,8 +55,8 @@ import re
 import time
 import subprocess
 
+
 def get_conf_value(config_file, key):
-    value = None
     try:
         config = open(config_file, 'r')
         for line in config.readlines():
@@ -99,8 +99,6 @@ class Holland:
             print "status error unable to retrieve log file modified time"
             sys.exit(1)
 
-
-
     def get_time_since_dump(self):
         dump = os.path.join(self.directory, self.backupset, 'newest')
         try:
@@ -128,8 +126,8 @@ class MySQL:
         self.creds_files = get_conf_value(self.backupset_config,
                                           'defaults-extra-file')
         if not self.creds_files:
-            self.creds_files =  get_conf_value(self.config_file,
-                                               'defaults-extra-file')
+            self.creds_files = get_conf_value(self.config_file,
+                                              'defaults-extra-file')
 
     # return true if credentials set
     def check_creds(self):
@@ -152,7 +150,7 @@ class MySQL:
                     try:
                         ping = subprocess.call([
                             "/usr/bin/mysqladmin",
-                            "--defaults-file="+f,"ping"],
+                            "--defaults-file="+f, "ping"],
                             stdout=DEVNULL,
                             stderr=DEVNULL)
                         if ping == 0:
@@ -162,7 +160,7 @@ class MySQL:
             elif self.user and self.password:
                 ping = subprocess.call([
                     "/usr/bin/mysqladmin",
-                    "-u",self.user,
+                    "-u", self.user,
                     "-p"+self.password,
                     "ping"],
                     stdout=DEVNULL,
@@ -192,7 +190,7 @@ class MySQL:
                     try:
                         status = subprocess.call([
                             "/usr/bin/mysqladmin",
-                            "--defaults-file="+f,"status"],
+                            "--defaults-file="+f, "status"],
                             stdout=DEVNULL,
                             stderr=DEVNULL)
                         if status == 0:
@@ -202,7 +200,7 @@ class MySQL:
             elif self.user and self.password:
                 status = subprocess.call([
                     "/usr/bin/mysqladmin",
-                    "-u",self.user,
+                    "-u", self.user,
                     "-p"+self.password,
                     "status"],
                     stdout=DEVNULL,
@@ -239,7 +237,6 @@ if __name__ == '__main__':
     dump_age = holland.get_time_since_dump()
     log_pos = holland.get_log_position()
 
-
     match = '\[ERROR\]'
     split = '[ERROR]'
     exclude = 'Warning: Skipping the data of table mysql.event'
@@ -255,7 +252,7 @@ if __name__ == '__main__':
 
     # check file is accessible
     if not os.access(log_file, os.R_OK):
-        print "status error unable to access file",log_file
+        print "status error unable to access file", log_file
         sys.exit(1)
 
     # read info from tracking file
@@ -287,7 +284,6 @@ if __name__ == '__main__':
         read_from_pos = 0
         prev_date = 0
 
-
     # find lines that match provided regex
     matched_lines = []
     reasons = []
@@ -295,7 +291,7 @@ if __name__ == '__main__':
         log = open(log_file, 'r')
         log.seek(read_from_pos)
         for line in log.readlines():
-            if re.search(match,line) and not re.search(exclude,line):
+            if re.search(match, line) and not re.search(exclude, line):
                 matched_lines.append(line)
                 reasons.append(line.split(split)[1].strip())
     except:
@@ -303,7 +299,6 @@ if __name__ == '__main__':
         sys.exit(1)
     else:
         log.close()
-
 
     # Get first and last error messages
     if len(reasons) > 0:
@@ -319,23 +314,22 @@ if __name__ == '__main__':
         try:
             tracking = open(tracking_file, 'w')
             tracking.write(str(log_modified)+','+str(read_from_pos)+','
-                +str(log_pos))
+                           +str(log_pos))
         except:
             print "status error unable to write to tracking file"
             sys.exit(1)
         else:
             tracking.close()
 
-
     # Finally check SQL
     sql = MySQL(backupset)
 
     print "status success holland checked"
-    print "metric log_age int64",log_age
-    print "metric dump_age int64",dump_age
-    print "metric error_count int64",len(matched_lines)
-    print "metric first_error string",first_error
-    print "metric last_error string",last_error
-    print "metric sql_creds_exist string",sql.check_creds()
-    print "metric sql_ping_succeeds string",sql.check_ping()
-    print "metric sql_status_succeeds string",sql.check_status()
+    print "metric log_age int64", log_age
+    print "metric dump_age int64", dump_age
+    print "metric error_count int64", len(matched_lines)
+    print "metric first_error string", first_error
+    print "metric last_error string", last_error
+    print "metric sql_creds_exist string", sql.check_creds()
+    print "metric sql_ping_succeeds string", sql.check_ping()
+    print "metric sql_status_succeeds string", sql.check_status()

--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -119,9 +119,11 @@ class MySQL:
         if get_conf_value(self.backupset_config, 'user'):
             self.user = get_conf_value(self.backupset_config, 'user')
             self.password = get_conf_value(self.backupset_config, 'password')
+            self.host = get_conf_value(self.backupset_config, 'host')
         else:
             self.user = get_conf_value(self.config_file, 'user')
             self.password = get_conf_value(self.config_file, 'password')
+            self.host = get_conf_value(self.config_file, 'host')
 
         self.creds_files = get_conf_value(self.backupset_config,
                                           'defaults-extra-file')
@@ -145,7 +147,14 @@ class MySQL:
     def check_ping(self):
         try:
             DEVNULL = open(os.devnull, 'wb')
-            if self.creds_files:
+            if self.host:
+                ping = subprocess.call([
+                    "/usr/bin/mysqladmin",
+                    "-h", self.host,
+                    "ping"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL)
+            elif self.creds_files:
                 for f in self.creds_files.split(','):
                     try:
                         ping = subprocess.call([
@@ -157,14 +166,6 @@ class MySQL:
                             break
                     except:
                         ping = 0
-            elif self.user and self.password:
-                ping = subprocess.call([
-                    "/usr/bin/mysqladmin",
-                    "-u", self.user,
-                    "-p"+self.password,
-                    "ping"],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL)
             else:
                 ping = subprocess.call([
                     "/usr/bin/mysqladmin",
@@ -185,7 +186,25 @@ class MySQL:
     def check_status(self):
         try:
             DEVNULL = open(os.devnull, 'wb')
-            if self.creds_files:
+            if self.user and self.password:
+                if self.host is None:
+                    status = subprocess.call([
+                        "/usr/bin/mysqladmin",
+                        "-u", self.user,
+                        "-p"+self.password,
+                        "status"],
+                        stdout=DEVNULL,
+                        stderr=DEVNULL)
+                else:
+                    status = subprocess.call([
+                        "/usr/bin/mysqladmin",
+                        "-h", self.host,
+                        "-u", self.user,
+                        "-p"+self.password,
+                        "status"],
+                        stdout=DEVNULL,
+                        stderr=DEVNULL)
+            elif self.creds_files:
                 for f in self.creds_files.split(','):
                     try:
                         status = subprocess.call([
@@ -197,14 +216,6 @@ class MySQL:
                             break
                     except:
                         status = 0
-            elif self.user and self.password:
-                status = subprocess.call([
-                    "/usr/bin/mysqladmin",
-                    "-u", self.user,
-                    "-p"+self.password,
-                    "status"],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL)
             else:
                 status = subprocess.call([
                     "/usr/bin/mysqladmin",


### PR DESCRIPTION
This should fix issues #90, #91, and #92:

#90:  This adds back in the "host" configuration that was removed when #85 was reverted.

#91: As that issue states, the priority of the checks should be with the credentials in the backupsets configuration files rather than the defaults-extra-files, so the if, elif is switched to check with the credentials found in the holland configuration files rather than use the MySQL defaults-extra-files.

#92: This is the major change here.  With Holland having the ability to have multiple backupsets configured at the same time, the check needs to read the holland configuration for the backupsets to check rather than defaulting to a fixed "default".  This logic changes the single backupset check to a list read from the holland configuration and then iterates through the list.  The logic, though, still only reports back one value for the monitoring check.  The value reported is the "worst case" value of the ones checked.

I also got rid of an extraneous variable ("value") in the code.