### PR TITLE
Remove quotes from holland password.

### DIFF
--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -122,11 +122,13 @@ class MySQL:
         self.backupset_config = "/etc/holland/backupsets/%s.conf" % backupset
         if get_conf_value(self.backupset_config, 'user'):
             self.user = get_conf_value(self.backupset_config, 'user')
-            self.password = get_conf_value(self.backupset_config, 'password')
+            self.password = get_conf_value(
+                self.backupset_config, 'password').strip('"\'')
             self.host = get_conf_value(self.backupset_config, 'host')
         else:
             self.user = get_conf_value(self.config_file, 'user')
-            self.password = get_conf_value(self.config_file, 'password')
+            self.password = get_conf_value(
+                self.config_file, 'password').strip('"\'')
             self.host = get_conf_value(self.config_file, 'host')
 
         self.creds_files = get_conf_value(self.backupset_config,

--- a/holland_mysqldump.py
+++ b/holland_mysqldump.py
@@ -122,13 +122,11 @@ class MySQL:
         self.backupset_config = "/etc/holland/backupsets/%s.conf" % backupset
         if get_conf_value(self.backupset_config, 'user'):
             self.user = get_conf_value(self.backupset_config, 'user')
-            self.password = get_conf_value(
-                self.backupset_config, 'password').strip('"\'')
+            self.password = get_conf_value(self.backupset_config, 'password')
             self.host = get_conf_value(self.backupset_config, 'host')
         else:
             self.user = get_conf_value(self.config_file, 'user')
-            self.password = get_conf_value(
-                self.config_file, 'password').strip('"\'')
+            self.password = get_conf_value(self.config_file, 'password')
             self.host = get_conf_value(self.config_file, 'host')
 
         self.creds_files = get_conf_value(self.backupset_config,
@@ -197,7 +195,7 @@ class MySQL:
                     status = subprocess.call([
                         "/usr/bin/mysqladmin",
                         "-u", self.user,
-                        "-p"+self.password,
+                        "-p"+self.password.strip('"\''),
                         "status"],
                         stdout=DEVNULL,
                         stderr=DEVNULL)
@@ -206,7 +204,7 @@ class MySQL:
                         "/usr/bin/mysqladmin",
                         "-h", self.host,
                         "-u", self.user,
-                        "-p"+self.password,
+                        "-p"+self.password.strip('"\''),
                         "status"],
                         stdout=DEVNULL,
                         stderr=DEVNULL)


### PR DESCRIPTION
The Holland MySQL check fails authentication when the backupset
configuration file includes quotes around the password as the check
mistakenly includes those quotes as part of the password.  This
strips off single or double quotes from around the password.
