### PR TITLE
exit after a snapshot

### DIFF
--- a/docker_stats_check.py
+++ b/docker_stats_check.py
@@ -107,7 +107,7 @@ class DockerService(object):
                 print 'metric network_rx_packets int64', s['network']['rx_packets']
                 print 'metric network_tx_bytes int64', s['network']['tx_bytes']
                 print 'metric network_tx_packets int64', s['network']['tx_packets']
-
+                sys.exit(0); 
         else:
             print 'status err failed to obtain docker container stats.'
             sys.exit(1)


### PR DESCRIPTION
The plugin used an api which streams container metrics. This made the plugin never "finish" and hence time out.

This will fix that.