### PR TITLE
redirect all output from nc command to remove the chance of false alarm

### DIFF
--- a/port_check.sh
+++ b/port_check.sh
@@ -38,7 +38,7 @@ if [ $PROTOCOL = "udp" ]; then
     OPTIONS="-u"
 fi
 
-nc ${OPTIONS} ${IP} ${PORT} < /dev/null
+nc ${OPTIONS} ${IP} ${PORT} < /dev/null > /dev/null 2>&1
 
 if [ $? -ne 0 ]; then
     echo "status Nothing listening on port ${IP}:${PORT} (${PROTOCOL})"


### PR DESCRIPTION
Services such as MySQL have an output that interrupts the status of this alarm. The if/then conditional is the main part of the script that Cloud Monitoring needs to read to function.