### PR TITLE
docker_stats_check: support for several network devices returned by API "stats" call and for current number of PIDs metric

### DIFF
--- a/docker_stats_check.py
+++ b/docker_stats_check.py
@@ -103,6 +103,7 @@ class DockerService(object):
                 print 'metric cpu_user_mode_usage int64', s['cpu_stats']['cpu_usage']['usage_in_usermode']
                 print 'metric memory_max_usage int64', s['memory_stats']['max_usage']
                 print 'metric memory_total_cache int64', s['memory_stats']['stats']['total_cache']
+                print 'metric pids_current int64', s['pids_stats']['current']
                 if s.has_key('network'):
                     print_network_stat(s['network'])
                 elif s.has_key('networks'):


### PR DESCRIPTION
Recent Docker versions (e.g., 17.03.0) return 'networks' dict which contains per-device statistics. Old versions return 'network' dict that doesn't distinguish different devices. This patch adds support for both 'network' and 'networks' dicts; it also prints per-device stats if available.
Second patch adds support for current number of PIDs in a container.