### PR TITLE
Bug fix in latest update to ubuntu_updates_check.sh

### DIFF
--- a/ubuntu_updates_check.sh
+++ b/ubuntu_updates_check.sh
@@ -41,7 +41,7 @@ fi
 if [ $((PENDING_OTHER+PENDING_SECURITY)) -gt 0 ]; then
   UPGRADABLE_PACKAGES=$(apt list --upgradable 2>/dev/null | grep -v Listing | awk -F'/' '{print $1}' | paste -sd ',' -)
 else
-  UPGRADABLE_PACKAGES="n/a"
+  UPGRADABLE_PACKAGES="none"
 fi
 
 echo "status Pending updates: security ${PENDING_SECURITY}, other: ${PENDING_OTHER}"

--- a/ubuntu_updates_check.sh
+++ b/ubuntu_updates_check.sh
@@ -40,6 +40,8 @@ fi
 
 if [ $((PENDING_OTHER+PENDING_SECURITY)) -gt 0 ]; then
   UPGRADABLE_PACKAGES=$(apt list --upgradable 2>/dev/null | grep -v Listing | awk -F'/' '{print $1}' | paste -sd ',' -)
+else
+  UPGRADABLE_PACKAGES="n/a"
 fi
 
 echo "status Pending updates: security ${PENDING_SECURITY}, other: ${PENDING_OTHER}"


### PR DESCRIPTION
The Rackspace Intelligence system needs to have a string of some sort, even when there are no upgradable packages.  In cases where there are not any upgradable packages, it will now return `n/a` instead of nothing so that Rackspace Intelligence has a string metric available.