### PR TITLE
Adding systemctl_status.sh

### DIFF
--- a/systemctl_status.sh
+++ b/systemctl_status.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# List of status codes:
+# https://www.freedesktop.org/software/systemd/man/systemctl.html#is-system-running
+
+STATE=$(systemctl is-system-running)
+echo "status ok"
+echo "metric systemctl_status string $STATE"
+
+: <<EOF
+# Example Alarm:
+if (metric['systemctl_status'] != "running") {
+  return new AlarmStatus(CRITICAL, 'SystemCTL status is #{systemctl_status}!');
+}
+return new AlarmStatus(OK, 'SystemCTL status is #{systemctl_status}');
+EOF


### PR DESCRIPTION
Simple plugin for returning the output of `systemctl is-system-running` as a string.

I use this for monitoring my CentOS servers.
